### PR TITLE
Performance improvements to Vector.

### DIFF
--- a/benchmark/Vector/back.php
+++ b/benchmark/Vector/back.php
@@ -1,0 +1,12 @@
+<?php
+require __DIR__ . '/../benchmark.php';
+
+$vector = Icecave\Collections\Vector::create(1);
+
+Benchmark::run(
+    50000,
+    null,
+    function ($i) use ($vector) {
+        $vector->back();
+    }
+);

--- a/benchmark/Vector/elements.php
+++ b/benchmark/Vector/elements.php
@@ -1,0 +1,16 @@
+<?php
+require __DIR__ . '/../benchmark.php';
+
+$vector = new Icecave\Collections\Vector;
+
+for ($i = 0; $i < 2000; ++$i) {
+    $vector->pushBack($i);
+}
+
+Benchmark::run(
+    1000,
+    null,
+    function ($i) use ($vector) {
+        $vector->elements();
+    }
+);

--- a/benchmark/Vector/front.php
+++ b/benchmark/Vector/front.php
@@ -1,0 +1,12 @@
+<?php
+require __DIR__ . '/../benchmark.php';
+
+$vector = Icecave\Collections\Vector::create(1);
+
+Benchmark::run(
+    50000,
+    null,
+    function ($i) use ($vector) {
+        $vector->front();
+    }
+);

--- a/benchmark/Vector/reverse.php
+++ b/benchmark/Vector/reverse.php
@@ -1,0 +1,16 @@
+<?php
+require __DIR__ . '/../benchmark.php';
+
+$vector = new Icecave\Collections\Vector;
+
+for ($i = 0; $i < 200000; ++$i) {
+    $vector->pushBack($i);
+}
+
+Benchmark::run(
+    1,
+    null,
+    function ($i) use ($vector) {
+        $vector->reverse();
+    }
+);

--- a/benchmark/Vector/reverseInPlace.php
+++ b/benchmark/Vector/reverseInPlace.php
@@ -1,0 +1,16 @@
+<?php
+require __DIR__ . '/../benchmark.php';
+
+$vector = new Icecave\Collections\Vector;
+
+for ($i = 0; $i < 200000; ++$i) {
+    $vector->pushBack($i);
+}
+
+Benchmark::run(
+    1,
+    null,
+    function ($i) use ($vector) {
+        $vector->reverseInPlace();
+    }
+);

--- a/benchmark/Vector/tryBack.php
+++ b/benchmark/Vector/tryBack.php
@@ -1,0 +1,12 @@
+<?php
+require __DIR__ . '/../benchmark.php';
+
+$vector = Icecave\Collections\Vector::create(1);
+
+Benchmark::run(
+    50000,
+    null,
+    function ($i) use ($vector) {
+        $vector->tryBack($element);
+    }
+);

--- a/benchmark/Vector/tryFront.php
+++ b/benchmark/Vector/tryFront.php
@@ -1,0 +1,12 @@
+<?php
+require __DIR__ . '/../benchmark.php';
+
+$vector = Icecave\Collections\Vector::create(1);
+
+Benchmark::run(
+    50000,
+    null,
+    function ($i) use ($vector) {
+        $vector->tryFront($element);
+    }
+);

--- a/benchmark/Vector/tryPopBack.php
+++ b/benchmark/Vector/tryPopBack.php
@@ -1,0 +1,14 @@
+<?php
+require __DIR__ . '/../benchmark.php';
+
+$vector = new Icecave\Collections\Vector;
+
+Benchmark::run(
+    50000,
+    function ($i) use ($vector) {
+        $vector->pushBack($i);
+    },
+    function ($i) use ($vector) {
+        $vector->tryPopBack($element);
+    }
+);

--- a/benchmark/Vector/tryPopFront.php
+++ b/benchmark/Vector/tryPopFront.php
@@ -1,0 +1,14 @@
+<?php
+require __DIR__ . '/../benchmark.php';
+
+$vector = new Icecave\Collections\Vector;
+
+Benchmark::run(
+    1000,
+    function ($i) use ($vector) {
+        $vector->pushFront($i);
+    },
+    function ($i) use ($vector) {
+        $vector->tryPopFront($element);
+    }
+);

--- a/src/Vector.php
+++ b/src/Vector.php
@@ -595,7 +595,10 @@ class Vector implements MutableRandomAccessInterface, Countable, IteratorAggrega
         if (!$this->size) {
             return false;
         }
-        $element = $this->popFront();
+
+        $element = $this->elements[0];
+        $this->shiftLeft(1, 1);
+        --$this->size;
 
         return true;
     }
@@ -648,7 +651,9 @@ class Vector implements MutableRandomAccessInterface, Countable, IteratorAggrega
         if (!$this->size) {
             return false;
         }
-        $element = $this->popBack();
+
+        $element = $this->elements[--$this->size];
+        $this->elements[$this->size] = null;
 
         return true;
     }
@@ -904,7 +909,8 @@ class Vector implements MutableRandomAccessInterface, Countable, IteratorAggrega
 
             foreach ($elements as $element) {
                 if ($index === $shiftIndex) {
-                    $actualExpansion = $this->expand(1);
+                    $this->expand(1);
+                    $actualExpansion = $this->capacity - $this->size;
                     $this->shiftRight($index, $actualExpansion);
                     $shiftIndex += $actualExpansion;
                 }
@@ -1435,20 +1441,16 @@ class Vector implements MutableRandomAccessInterface, Countable, IteratorAggrega
         $targetCapacity = $this->size + $count;
 
         if ($this->capacity >= $targetCapacity) {
-            return $this->capacity - $this->size;
+            return;
         } elseif (0 === $this->capacity) {
-            $newCapacity = $targetCapacity;
+            $this->capacity = $targetCapacity;
         } else {
-            $newCapacity = $this->capacity;
-            while ($newCapacity < $targetCapacity) {
-                $newCapacity <<= 1;
+            while ($this->capacity < $targetCapacity) {
+                $this->capacity <<= 1;
             }
         }
 
-        $this->elements->setSize($newCapacity);
-        $this->capacity = $newCapacity;
-
-        return $newCapacity - $this->size;
+        $this->elements->setSize($this->capacity);
     }
 
     private $elements;

--- a/src/Vector.php
+++ b/src/Vector.php
@@ -396,7 +396,8 @@ class Vector implements MutableRandomAccessInterface, Countable, IteratorAggrega
         if (!$this->size) {
             return false;
         }
-        $element = $this->front();
+
+        $element = $this->elements[0];
 
         return true;
     }
@@ -428,7 +429,8 @@ class Vector implements MutableRandomAccessInterface, Countable, IteratorAggrega
         if (!$this->size) {
             return false;
         }
-        $element = $this->back();
+
+        $element = $this->elements[$this->size - 1];
 
         return true;
     }

--- a/src/Vector.php
+++ b/src/Vector.php
@@ -146,12 +146,9 @@ class Vector implements MutableRandomAccessInterface, Countable, IteratorAggrega
     public function elements()
     {
         $elements = array();
-        foreach ($this->elements as $index => $element) {
-            if ($index >= $this->size) {
-                break;
-            } else {
-                $elements[] = $element;
-            }
+
+        for ($index = 0; $index < $this->size; ++$index) {
+            $elements[] = $this->elements[$index];
         }
 
         return $elements;

--- a/src/Vector.php
+++ b/src/Vector.php
@@ -25,7 +25,6 @@ class Vector implements MutableRandomAccessInterface, Countable, IteratorAggrega
             $this->size = count($elements);
             $this->capacity = $this->size;
         } else {
-            $this->capacity = 0;
             $this->clear();
             if (null !== $elements) {
                 $this->insertMany(0, $elements);
@@ -467,13 +466,9 @@ class Vector implements MutableRandomAccessInterface, Countable, IteratorAggrega
         $result = new static;
         $result->resize($this->size);
 
-        $target = $this->size - 1;
-        foreach ($this->elements as $index => $element) {
-            if ($index >= $this->size) {
-                break;
-            } else {
-                $result->elements[$target--] = $element;
-            }
+        $target = 0;
+        for ($source = $this->size - 1; $source >= 0; --$source) {
+            $result->elements[$target++] = $this->elements[$source];
         }
 
         return $result;


### PR DESCRIPTION
@koden-km Thought I'd open this to discuss the approaches that work, for example iterating over the `SplFixedArray` with a for loop and dereferencing using `[$index]` is faster than iteration with `foreach`, at least in the cases where iteration must terminate at `$this->size` rather than `capacity` - there are plenty of places where this idiom is used in `Vector` that would likely see improvement.

As a slightly longer-term goal I'd like to get the native PHP implementation of `Vector` as performant as it can be before having a serious go at a C implementation (be it using Zephir, or hand-rolled).

Some ideas, to be individually benchmarked ...
- [ ] Change `foreach` loops to `for` when iterating over internal `SplFixedArray`
- [ ] Do not expand exponentially on inserts (only on push)
- [ ] Growth factor of 1.5 (currently 2)
- [ ] `shiftLeft` might see improvements from knowing about the intended size (knowing how many elements it needs to set to null, etc - it currently always shifts full capacity). This is currently one of the slowest things when compounded, though not necessarily important as it's mostly used for non-tail removals, not a vectors strong point anyway
- [ ] `validateIndex` return new index rather than use reference
- [ ] `insertRange` et al shifting during the same loop as new insertions
- [ ] eliminate `call_user_func` (maybe needs to wait until 5.3 support is dropped)
- [ ] sorting is a joke right now! especially `inPlace` variant which is not in-place at all other than the fact that no new `Vector` is created
- [ ] `partition` might benefit from some pre-reservation of result vectors
- [ ] `indexOf` et al should use direct implementation rather than `find`
